### PR TITLE
Fix Pikachu filecount

### DIFF
--- a/pkNX.Game/GameLocation.cs
+++ b/pkNX.Game/GameLocation.cs
@@ -62,7 +62,7 @@ namespace pkNX.Game
         private const int FILECOUNT_SM = 311;
         private const int FILECOUNT_USUM = 333;
         private const int FILECOUNT_GE = 27818;
-        private const int FILECOUNT_GP = 27822;
+        private const int FILECOUNT_GP = 27816;
 
         private static GameVersion GetGameFromCount(int fileCount, string romfs)
         {


### PR DESCRIPTION
27816 for just RomFS, 2 files less than Eevee.