### PR TITLE
Rename move rand type options

### DIFF
--- a/pkNX.Randomization/Randomizers/MoveRandType.cs
+++ b/pkNX.Randomization/Randomizers/MoveRandType.cs
@@ -3,8 +3,8 @@ namespace pkNX.Randomization
     public enum MoveRandType
     {
         None,
-        Random,
-        CurrentMoves,
+        RandomMoves,
+        LevelUpMoves,
         HighPowered,
         MetronomeOnly,
     }

--- a/pkNX.Randomization/Randomizers/Settings/TrainerRandSettings.cs
+++ b/pkNX.Randomization/Randomizers/Settings/TrainerRandSettings.cs
@@ -79,7 +79,7 @@ namespace pkNX.Randomization
 
         #region Moves
         [Category(Moves), Description("How movesets are randomized/chosen for each PKM.")]
-        public MoveRandType MoveRandType { get; set; } = MoveRandType.Random;
+        public MoveRandType MoveRandType { get; set; } = MoveRandType.RandomMoves;
         #endregion
     }
 }

--- a/pkNX.Randomization/Randomizers/TrainerRandomizer.cs
+++ b/pkNX.Randomization/Randomizers/TrainerRandomizer.cs
@@ -266,10 +266,10 @@ namespace pkNX.Randomization
         {
             switch (Settings.MoveRandType)
             {
-                case MoveRandType.Random: // Random
+                case MoveRandType.RandomMoves: // Random
                     pk.Moves = RandMove.GetRandomMoveset(pk.Species);
                     break;
-                case MoveRandType.CurrentMoves:
+                case MoveRandType.LevelUpMoves:
                     pk.Moves = Learn.GetCurrentMoves(pk.Species, pk.Form, pk.Level);
                     break;
                 case MoveRandType.HighPowered:


### PR DESCRIPTION
People keep asking me "where's the level up moves option???" so let's be more precise for those it doesn't click with.