### PR TITLE
Update Fody to 6.0.3 (latest stable)

### DIFF
--- a/pkNX.WinForms/packages.config
+++ b/pkNX.WinForms/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Costura.Fody" version="4.1.0" targetFramework="net461" />
-  <package id="Fody" version="6.0.0" targetFramework="net461" developmentDependency="true" />
+  <package id="Fody" version="6.0.3" targetFramework="net461" developmentDependency="true" />
 </packages>

--- a/pkNX.WinForms/pkNX.WinForms.csproj
+++ b/pkNX.WinForms/pkNX.WinForms.csproj
@@ -232,12 +232,12 @@
     <Content Include="icon.ico" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Fody.6.0.0\build\Fody.targets" Condition="Exists('..\packages\Fody.6.0.0\build\Fody.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Fody.6.0.0\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.6.0.0\build\Fody.targets'))" />
     <Error Condition="!Exists('..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props'))" />
+    <Error Condition="!Exists('..\packages\Fody.6.0.3\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.6.0.3\build\Fody.targets'))" />
   </Target>
+  <Import Project="..\packages\Fody.6.0.3\build\Fody.targets" Condition="Exists('..\packages\Fody.6.0.3\build\Fody.targets')" />
 </Project>


### PR DESCRIPTION
Yay for 
> D:\git_prj\pkNX3\packages\Fody.6.0.0\build\Fody.targets(38,12): error MSB4086: A numeric comparison was attempted on "$(MsBuildMajorVersion)" that evaluates to "" instead of a number, in condition "($(MsBuildMajorVersion) < 16)".