### PR TITLE
Document more of GiftEncounter8

### DIFF
--- a/pkNX.Structures/Encounter/Gen8/FlatGift/GiftEncounter8.cs
+++ b/pkNX.Structures/Encounter/Gen8/FlatGift/GiftEncounter8.cs
@@ -2,31 +2,33 @@ namespace pkNX.Structures
 {
     public class EncounterGift8
     {
-        public sbyte Field_00 { get; set; }
-        public sbyte Field_01 { get; set; }
-        public sbyte Field_02 { get; set; }
-        public byte Ball { get; set; }
-        public sbyte Field_04 { get; set; }
+        public int IsEgg { get; set; }
+        public int AltForm { get; set; }
+        public int DynamaxLevel { get; set; }
+        public int Ball { get; set; }
+        public int Field_04 { get; set; }
         public ulong Hash1 { get; set; }
-        public sbyte CanGigantamax { get; set; }
-        public sbyte Field_07 { get; set; }
-        public sbyte Level { get; set; }
-        public uint Species { get; set; }
-        public sbyte Field_0A { get; set; }
-        public sbyte Field_0B { get; set; }
-        public sbyte Field_0C { get; set; }
-        public sbyte Field_0D { get; set; }
-        public sbyte Field_0E { get; set; }
+        public bool CanGigantamax { get; set; }
+        public int HeldItem { get; set; }
+        public int Level { get; set; }
+        public int Species { get; set; }
+        public int Field_0A { get; set; }
+        public int Field_0B { get; set; }
+        public int Field_0C { get; set; }
+        public int Field_0D { get; set; }
+        public int Field_0E { get; set; }
         public ulong Hash2 { get; set; }
-        public uint Field_10 { get; set; }
-        public uint ShinyLock { get; set; }
-        public uint Nature { get; set; }
-        public sbyte Field_13 { get; set; }
-        public sbyte IV_Hp { get; set; }
-        public sbyte IV_Atk { get; set; }
-        public sbyte IV_Def { get; set; }
-        public sbyte IV_SpAtk { get; set; }
-        public sbyte IV_SpDef { get; set; }
-        public sbyte IV_Spe { get; set; }
+        public int Field_10 { get; set; }
+        public int ShinyLock { get; set; }
+        public int Nature { get; set; }
+        public int Gender { get; set; }
+        public int IV_Hp { get; set; }
+        public int IV_Atk { get; set; }
+        public int IV_Def { get; set; }
+        public int IV_SpAtk { get; set; }
+        public int IV_SpDef { get; set; }
+        public int IV_Spe { get; set; }
+        public int Ability { get; set; }
+        public int SpecialMove { get; set; }
     }
 }

--- a/pkNX.WinForms/Resources/Flatbuffers/EncounterGift8Archive.fbs
+++ b/pkNX.WinForms/Resources/Flatbuffers/EncounterGift8Archive.fbs
@@ -5,16 +5,16 @@ table EncounterGift8Archive {
 }
 
 table EncounterGift8 {
-  Field_00:byte;
-  Field_01:byte;
-  Field_02:byte;
-  Ball:ubyte;
+  IsEgg:uint;
+  AltForm:byte;
+  DynamaxLevel:byte;
+  Ball:uint;
   Field_04:byte;
 
   Hash1:ulong;
 
-  CanGigantamax:byte;
-  Field_07:byte;
+  CanGigantamax:bool;
+  HeldItem:uint;
   Level:byte;
   Species:uint;
   Field_0A:byte;
@@ -25,10 +25,10 @@ table EncounterGift8 {
 
   Hash2:ulong;
 
-  Field_10:uint;
+  Field_10:byte;
   ShinyLock:uint;
   Nature:uint;
-  Field_13:byte;
+  Gender:byte;
 
   IV_Hp:byte;
   IV_Atk:byte;
@@ -36,6 +36,9 @@ table EncounterGift8 {
   IV_SpAtk:byte;
   IV_SpDef:byte;
   IV_Spe:byte;
+
+  Ability:uint;
+  SpecialMove:uint;
 }
 
 root_type EncounterGift8Archive;

--- a/pkNX.WinForms/Subforms/GenericEditor.Designer.cs
+++ b/pkNX.WinForms/Subforms/GenericEditor.Designer.cs
@@ -40,7 +40,7 @@
             this.Grid.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Grid.Location = new System.Drawing.Point(0, 0);
             this.Grid.Name = "Grid";
-            this.Grid.Size = new System.Drawing.Size(461, 494);
+            this.Grid.Size = new System.Drawing.Size(461, 611);
             this.Grid.TabIndex = 0;
             // 
             // B_Save
@@ -87,7 +87,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(461, 494);
+            this.ClientSize = new System.Drawing.Size(461, 611);
             this.Controls.Add(this.B_Rand);
             this.Controls.Add(this.B_Dump);
             this.Controls.Add(this.CB_EntryName);


### PR DESCRIPTION
`Ability` wasn't defined before, and neither was `SpecialMove`!

The latter works identically to how it did in the Alola games (e.g. Surf Pikachu) where the assigned Move is forced onto the last available slot in the gift's moveset.

Tested all fields and there are no more crashes; this PR resolves #40.