### PR TITLE
Added editing nest drop tables and raid bonus drop tables. (basic)

### DIFF
--- a/pkNX.Structures/Encounter/Gen8/FlatNest/NestHoleReward8Archive.cs
+++ b/pkNX.Structures/Encounter/Gen8/FlatNest/NestHoleReward8Archive.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel;
 using System.Runtime.InteropServices.ComTypes;
+using Newtonsoft.Json;
 
 namespace pkNX.Structures
 {
@@ -11,6 +13,7 @@ namespace pkNX.Structures
     public interface INestHoleRewardTable
     {
         ulong TableID { get; set; }
+        [JsonIgnore]
         INestHoleReward[] Rewards { get; }
     }
 
@@ -19,6 +22,8 @@ namespace pkNX.Structures
         public ulong TableID { get; set; }
         public NestHoleReward8[] Entries { get; set; }
 
+        [Browsable(false)]
+        [JsonIgnore]
         public INestHoleReward[] Rewards => Entries;
     }
 
@@ -33,5 +38,7 @@ namespace pkNX.Structures
         public uint EntryID { get; set; }
         public uint ItemID { get; set; }
         public uint[] Values { get; set; }
+
+        public override string ToString() => $"{EntryID:0} - {ItemID:0000}";
     }
 }

--- a/pkNX.WinForms/Dumping/FlatBufferConverter.cs
+++ b/pkNX.WinForms/Dumping/FlatBufferConverter.cs
@@ -114,6 +114,7 @@ namespace pkNX.WinForms
             File.WriteAllText(jsonPath, text);
             var args = GetArgumentsSerialize(jsonName, fbsName);
             RunFlatC(args);
+            File.Delete(jsonPath);
         }
 
         private static void RunFlatC(string args)

--- a/pkNX.WinForms/MainEditor/EditorSWSH.cs
+++ b/pkNX.WinForms/MainEditor/EditorSWSH.cs
@@ -236,6 +236,47 @@ namespace pkNX.WinForms.Controls
             fp[0] = data_table.Write();
         }
 
+        public void EditRaidRewards()
+        {
+            IFileContainer fp = ROM.GetFile(GameFile.NestData);
+            var data_table = new GFPack(fp[0]);
+            const string nest = "nest_hole_drop_rewards.bin";
+            byte[] originalData = data_table.GetDataFileName(nest);
+            var nest_drops = FlatBufferConverter.DeserializeFrom<NestHoleReward8Archive>(originalData);
+
+            var arr = nest_drops.Tables;
+            var cache = new DataCache<NestHoleReward8Table>(arr);
+            var names = arr.Select((z, i) => $"{z.TableID}").ToArray();
+            using var form = new GenericEditor<NestHoleReward8Table>(cache, names, "Raid Rewards");
+            form.ShowDialog();
+            if (!form.Modified)
+                return;
+
+            var data = FlatBufferConverter.SerializeFrom(nest_drops);
+            data_table.SetDataFileName(nest, data);
+            fp[0] = data_table.Write();
+        }
+
+        public void EditRBonusRewards()
+        {
+            IFileContainer fp = ROM.GetFile(GameFile.NestData);
+            var data_table = new GFPack(fp[0]);
+            const string nest = "nest_hole_bonus_rewards.bin";
+            var nest_bonus = FlatBufferConverter.DeserializeFrom<NestHoleReward8Archive>(data_table.GetDataFileName(nest));
+
+            var arr = nest_bonus.Tables;
+            var cache = new DataCache<NestHoleReward8Table>(arr);
+            var names = arr.Select((z, i) => $"{z.TableID}").ToArray();
+            using var form = new GenericEditor<NestHoleReward8Table>(cache, names, "RBonus Rewards");
+            form.ShowDialog();
+            if (!form.Modified)
+                return;
+
+            var data = FlatBufferConverter.SerializeFrom(nest_bonus);
+            data_table.SetDataFileName(nest, data);
+            fp[0] = data_table.Write();
+        }
+
         public void EditStatic()
         {
             var arc = ROM.GetFile(GameFile.EncounterStatic);


### PR DESCRIPTION
- added some info in NestHoleReward8Archive.cs to make things pretty in the PropertyGrid editor uses and also to fix exclude stuff from the json/fb serialization/deserialization process.
- fixed a bug in FlatBufferConverter.cs related to creating a json file for a particular structure when saving, not deleting it and next time when serializing a different structure, that json file would be used because it would be first returned.