### PR TITLE
Set positive Result when saving Wild Pokemon Randomization

### DIFF
--- a/pkNX.WinForms/Subforms/GGWE.cs
+++ b/pkNX.WinForms/Subforms/GGWE.cs
@@ -291,6 +291,8 @@ namespace pkNX.WinForms
             EL_Super.SaveCurrent();
             EL_Sky.SaveCurrent();
 
+            Result = "OK";
+
             Close();
         }
 


### PR DESCRIPTION
Without this change, https://github.com/kwsch/pkNX/blob/master/pkNX.WinForms/MainEditor/EditorGG.cs#L209 will never succeed and never write the results.