### PR TITLE
Added options to boost chance of Legendary/Mythical on Trainers

### DIFF
--- a/pkNX.Randomization/Randomizers/Settings/SpeciesSettings.cs
+++ b/pkNX.Randomization/Randomizers/Settings/SpeciesSettings.cs
@@ -71,6 +71,9 @@ namespace pkNX.Randomization
         [Category(Misc), Description("Requires the randomized species to have a similar typing as the original species. Note: might not be used by all randomizers.")]
         public bool Type { get; set; } = false;
 
+        [Category(Misc), Description("Makes the appearance of Legendary Pokémon to appear on boosted rates (percent). Ignored if 0 or Legends setting on Species is False.")]
+        public float LegendsChance { get; set; } = 2.5f;
+
         /// <summary>
         /// Gets an array of Species according to the specified settings.
         /// </summary>

--- a/pkNX.Randomization/Randomizers/Settings/SpeciesSettings.cs
+++ b/pkNX.Randomization/Randomizers/Settings/SpeciesSettings.cs
@@ -71,8 +71,13 @@ namespace pkNX.Randomization
         [Category(Misc), Description("Requires the randomized species to have a similar typing as the original species. Note: might not be used by all randomizers.")]
         public bool Type { get; set; } = false;
 
+        /// <summary>Makes the appearance of Legendary Pokémon to appear on boosted rates (percent). Ignored if 0 or Legends setting on Species is False.</summary>
         [Category(Misc), Description("Makes the appearance of Legendary Pokémon to appear on boosted rates (percent). Ignored if 0 or Legends setting on Species is False.")]
         public float LegendsChance { get; set; } = 2.5f;
+
+        /// <summary>Makes the appearance of Event (Mythical) Pokémon to appear on boosted rates (percent). Ignored if 0 or Legends setting on Species is False.</summary>
+        [Category(Misc), Description("Makes the appearance of Event (Mythical) Pokémon to appear on boosted rates (percent).")]
+        public float EventsChance { get; set; } = 2.5f;
 
         /// <summary>
         /// Gets an array of Species according to the specified settings.

--- a/pkNX.Randomization/Randomizers/SpeciesRandomizer.cs
+++ b/pkNX.Randomization/Randomizers/SpeciesRandomizer.cs
@@ -28,11 +28,14 @@ namespace pkNX.Randomization
         {
             s = settings;
             var list = s.GetSpecies(Game.MaxSpeciesID, Game.Generation).Except(banlist);
+            var legends = Game.Generation == 8 ? Legal.Legendary_8 : Legal.Legendary_1;
             RandSpec = new GenericRandomizer<int>(list.ToArray());
+            RandLegend = new GenericRandomizer<int>(legends.ToArray());
         }
 
         #region Random Species Filtering Parameters
         private GenericRandomizer<int> RandSpec = new(Array.Empty<int>());
+        private GenericRandomizer<int> RandLegend = new(Array.Empty<int>());
         private int loopctr;
         private const int l = 10; // tweakable scalars
         private const int h = 11;
@@ -92,6 +95,12 @@ namespace pkNX.Randomization
         private bool GetNewSpecies(int currentSpecies, PersonalInfo oldpkm, out int newSpecies)
         {
             newSpecies = RandSpec.Next();
+
+            if ((Util.Random.Next(0, 100 + 1) < s.LegendsChance) && s.Legends)
+            {
+                newSpecies = RandLegend.Next();
+            }
+
             var pkm = SpeciesStat[newSpecies];
 
             if (IsSpeciesReplacementBad(newSpecies, currentSpecies)) // no A->A randomization

--- a/pkNX.Randomization/Randomizers/SpeciesRandomizer.cs
+++ b/pkNX.Randomization/Randomizers/SpeciesRandomizer.cs
@@ -28,14 +28,20 @@ namespace pkNX.Randomization
         {
             s = settings;
             var list = s.GetSpecies(Game.MaxSpeciesID, Game.Generation).Except(banlist);
-            var legends = Game.Generation == 8 ? Legal.Legendary_8 : Legal.Legendary_1;
+
+            legends = Game.Generation == 8 ? Legal.Legendary_8 : Legal.Legendary_1;
+            events = Game.Generation == 8 ? Legal.Mythical_8 : Legal.Mythical_GG;
             RandSpec = new GenericRandomizer<int>(list.ToArray());
             RandLegend = new GenericRandomizer<int>(legends.ToArray());
+            RandEvent = new GenericRandomizer<int>(events.ToArray());
         }
 
         #region Random Species Filtering Parameters
         private GenericRandomizer<int> RandSpec = new(Array.Empty<int>());
         private GenericRandomizer<int> RandLegend = new(Array.Empty<int>());
+        private GenericRandomizer<int> RandEvent = new(Array.Empty<int>());
+        private int[] legends;
+        private int[] events;
         private int loopctr;
         private const int l = 10; // tweakable scalars
         private const int h = 11;
@@ -94,11 +100,22 @@ namespace pkNX.Randomization
 
         private bool GetNewSpecies(int currentSpecies, PersonalInfo oldpkm, out int newSpecies)
         {
+            bool isLegend = false;
+
             newSpecies = RandSpec.Next();
+
+            // If we randomly got a legendary or mythical, not really a need to reroll
+            if (legends.Contains(newSpecies) || events.Contains(newSpecies)) isLegend = true;
 
             if ((Util.Random.Next(0, 100 + 1) < s.LegendsChance) && s.Legends)
             {
-                newSpecies = RandLegend.Next();
+                if (!isLegend) newSpecies = RandLegend.Next();
+                isLegend = true;
+            }
+
+            if ((Util.Random.Next(0, 100 + 1) < s.EventsChance) && s.Events)
+            {
+                if (!isLegend) newSpecies = RandEvent.Next();
             }
 
             var pkm = SpeciesStat[newSpecies];

--- a/pkNX.Structures/Legality/Species.cs
+++ b/pkNX.Structures/Legality/Species.cs
@@ -106,7 +106,21 @@ namespace pkNX.Structures
 
         public static readonly int[] Legendary_USUM = Legendary_SM.Concat(new[] { 804, 805, 806 }).ToArray(); // Poipole, Blacephalon, Stakataka
 
-        public static readonly int[] Legendary_8 = Legendary_USUM.Concat(new[] { 888, 889, 890 }).ToArray(); // Zacian, Zamazenta, Eternatus
+        public static readonly int[] Legendary_8 = Legendary_USUM.Concat(new[] 
+        {
+            #region Legendary
+            888, // Zacian
+            889, // Zamazenta
+            890, // Eternatus
+            891, // Kubfu
+            892, // Urshifu
+            894, // Regieleki
+            895, // Regidrago
+            896, // Glastrier
+            897, // Spectrier
+            898, // Calyrex
+            #endregion
+        }).ToArray();
 
         public static readonly int[] Mythical_1 = { 151 }; // Mew
 
@@ -136,5 +150,7 @@ namespace pkNX.Structures
         public static readonly int[] Mythical_USUM = Mythical_SM.Concat(new[] { 807 }).ToArray(); // Zeraora
 
         public static readonly int[] Mythical_GG = Mythical_1.Concat(new[] { 809 }).ToArray(); // Melmetal
+
+        public static readonly int[] Mythical_8 = Mythical_USUM.Concat(new[] { 809, 893 }).ToArray(); // Melmetal, Zarude
     }
 }


### PR DESCRIPTION
Basically two boost Legendary/Mythical appearances on Trainers with a certain rate established. 

Also since I was at this I updated the Legal.Legendary_8 list with the IoA/CT-added legendaries (same with Mythicals).

![image](https://user-images.githubusercontent.com/5099644/106786715-25f20680-664f-11eb-91b4-8d9b3102b90d.png)
