### PR TITLE
Differentiate between SW/SH

### DIFF
--- a/pkNX.Game/GameLocation.cs
+++ b/pkNX.Game/GameLocation.cs
@@ -49,7 +49,7 @@ namespace pkNX.Game
                 return null;
 
             var files = Directory.GetFiles(romfs, "*", SearchOption.AllDirectories);
-            var game = GetGameFromCount(files.Length, romfs);
+            var game = GetGameFromCount(files.Length, romfs, exefs);
             if (game == GameVersion.Invalid)
                 return null;
             return new GameLocation(romfs, exefs, game);
@@ -67,7 +67,7 @@ namespace pkNX.Game
         private const int FILECOUNT_SWSH_2 = 46867; // Ver. 1.2.0 update (Isle of Armor)
         private const int FILECOUNT_SWSH_3 = 50494; // Ver. 1.3.0 update (Crown Tundra)
 
-        private static GameVersion GetGameFromCount(int fileCount, string romfs)
+        private static GameVersion GetGameFromCount(int fileCount, string romfs, string exefs)
         {
             switch (fileCount)
             {
@@ -95,8 +95,14 @@ namespace pkNX.Game
                 case FILECOUNT_SWSH:
                 case FILECOUNT_SWSH_1:
                 case FILECOUNT_SWSH_2:
-                case FILECOUNT_SWSH_3:
                     return GameVersion.SW; // todo: differentiate between SW/SH
+                case FILECOUNT_SWSH_3:
+                    // Unlike SM and USUM, the file structure between these two games are identical,
+                    // so we identify the game by the size of the main binary.
+                    var main = Path.Combine(exefs, "main");
+                    if (new FileInfo(main).Length == 21163058)
+                        return GameVersion.SW; 
+                    return GameVersion.SH;
                 default:
                     return GameVersion.Invalid;
             }

--- a/pkNX.Game/GameManagerSWSH.cs
+++ b/pkNX.Game/GameManagerSWSH.cs
@@ -9,17 +9,13 @@ namespace pkNX.Game
     public class GameManagerSWSH : GameManager
     {
         public GameManagerSWSH(GameLocation rom, int language) : base(rom, language) { }
-        private GameVersion ActualGame = GameVersion.SW;
-        public string TitleID => ActualGame == GameVersion.SW ? Sword : Shield;
+        public string TitleID => Game == GameVersion.SW ? Sword : Shield;
         private const string Sword = "0100ABF008968000";
         private const string Shield = "01008DB008C2C000";
-
-        public bool IsSword { get; set; } = true;
 
         protected override void SetMitm()
         {
             var basePath = Path.GetDirectoryName(ROM.RomFS);
-            ActualGame = !IsSword ? GameVersion.SH : GameVersion.SW;
             var redirect = Path.Combine(basePath, TitleID);
             FileMitm.SetRedirect(basePath, redirect);
         }


### PR DESCRIPTION
This PR adds the ability for pkNX to differentiate between Pokémon Sword and Shield. It looks to me like the file structure between the two are identical, so the check I implemented here looks at the size of `exefs/main`. This is only implemented for update 3 because those are the only files I have, but other versions of the games could be easily added here.

![image](https://user-images.githubusercontent.com/13039555/109409628-66992300-7962-11eb-9a25-9a2cf45a518c.png)