### PR TITLE
Merge version specific buttons.

### DIFF
--- a/pkNX.WinForms/MainEditor/EditorGG.cs
+++ b/pkNX.WinForms/MainEditor/EditorGG.cs
@@ -218,8 +218,7 @@ namespace pkNX.WinForms.Controls
                 file[0] = objs.SelectMany(z => z.Write()).ToArray();
         }
 
-        public void EditWild_GP() => PopWildEdit(GameFile.WildData1);
-        public void EditWild_GE() => PopWildEdit(GameFile.WildData2);
+        public void EditWild() => PopWildEdit(Game == GameVersion.GP ? GameFile.WildData1 : GameFile.WildData2);
 
         private void PopWildEdit(GameFile type)
         {

--- a/pkNX.WinForms/MainEditor/EditorSWSH.cs
+++ b/pkNX.WinForms/MainEditor/EditorSWSH.cs
@@ -186,8 +186,7 @@ namespace pkNX.WinForms.Controls
             FileMitm.WriteAllBytes(path, data);
         }
 
-        public void EditWild_SW() => PopWildEdit("k");
-        public void EditWild_SH() => PopWildEdit("t");
+        public void EditWild() => PopWildEdit(Game == GameVersion.SW ? "k" : "t");
 
         private void PopWildEdit(string file)
         {


### PR DESCRIPTION
This PR merges the `Wild_SW` and `Wild_SH` buttons into one `Wild` button, for a better user experience.
![image](https://user-images.githubusercontent.com/13039555/109409848-10c57a80-7964-11eb-88af-3ed386641cba.png)
I've done the same for the LGPE version specific buttons. I don't have those files to test with, but I don't foresee these changes causing anything horrible to happen.