### PR TITLE
Fix Linux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pkNX also provides some utility to extract from supported container types, e.g. 
 
 pkNX is a Windows Forms application which requires [.NET Framework v4.6](https://www.microsoft.com/en-us/download/details.aspx?id=48137).
 
-The executable can be built with any compiler that supports C# 8.
+The executable can be built with any compiler that supports C# 9.
 
 ## Dependencies
 

--- a/pkNX.Containers/pkNX.Containers.csproj
+++ b/pkNX.Containers/pkNX.Containers.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <Description>Packing &amp; Unpacking</Description>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>

--- a/pkNX.Game/pkNX.Game.csproj
+++ b/pkNX.Game/pkNX.Game.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <Description>Game Data Manager</Description>
     <LangVersion>9</LangVersion>
   </PropertyGroup>

--- a/pkNX.Randomization/pkNX.Randomization.csproj
+++ b/pkNX.Randomization/pkNX.Randomization.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <Description>Randomizer Utility</Description>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>

--- a/pkNX.Sprites/pkNX.Sprites.csproj
+++ b/pkNX.Sprites/pkNX.Sprites.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;net461</TargetFrameworks>
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+	  <PackageReference Include="System.Resources.Extensions" Version="5.0.0" />
     <Compile Update="Properties\Resources.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
@@ -27,7 +28,6 @@
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net5'))">
     <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
-    <PackageReference Include="System.Resources.Extensions" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/pkNX.Sprites/pkNX.Sprites.csproj
+++ b/pkNX.Sprites/pkNX.Sprites.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net46</TargetFrameworks>
+    <TargetFrameworks>net5.0;net461</TargetFrameworks>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/pkNX.Sprites/pkNX.Sprites.csproj
+++ b/pkNX.Sprites/pkNX.Sprites.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net5.0;net461</TargetFrameworks>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
+    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
 
   <ItemGroup>

--- a/pkNX.Structures/Encounter/Gen8/FlatStatic/EncounterStatic8.cs
+++ b/pkNX.Structures/Encounter/Gen8/FlatStatic/EncounterStatic8.cs
@@ -73,7 +73,7 @@ namespace pkNX.Structures
         public enum Scenario
         {
             None,
-            Legendary_Pokémon,
+            Legendary_Pokemon,
             _2,
             _3,
             Eternatus,

--- a/pkNX.Structures/pkNX.Structures.csproj
+++ b/pkNX.Structures/pkNX.Structures.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <Description>Data Structures</Description>
     <LangVersion>9</LangVersion>
   </PropertyGroup>

--- a/pkNX.WinForms/Dumping/FlatBufferConverter.cs
+++ b/pkNX.WinForms/Dumping/FlatBufferConverter.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.IO;
 using System.Windows.Forms;
 using Newtonsoft.Json;
@@ -119,9 +119,20 @@ namespace pkNX.WinForms
 
         private static void RunFlatC(string args)
         {
-            var fcp = Path.Combine(FlatPath, "flatc.exe");
-            if (!File.Exists(fcp))
-                File.WriteAllBytes(fcp, Resources.flatc);
+            String fcp = "";
+            // If there's a flatc on the path, prefer it.
+            foreach (var path in Environment.GetEnvironmentVariable("PATH").Split(Path.PathSeparator))
+            {
+                var fullPath = Path.Combine(path, "flatc");
+                if (File.Exists(fullPath))
+                    fcp = fullPath;
+            }
+            if (string.IsNullOrEmpty(fcp))
+            {
+                fcp = Path.Combine(FlatPath, "flatc.exe");
+                if (!File.Exists(fcp))
+                    File.WriteAllBytes(fcp, Resources.flatc);
+            }
 
             using var process = new Process
             {
@@ -130,8 +141,8 @@ namespace pkNX.WinForms
                     WorkingDirectory = FlatPath,
                     WindowStyle = ProcessWindowStyle.Hidden,
                     CreateNoWindow = true,
-                    FileName = "cmd.exe",
-                    Arguments = $"/C flatc {args} & exit",
+                    FileName = fcp,
+                    Arguments = args,
                 }
             };
             process.Start();

--- a/pkNX.WinForms/Dumping/FlatBufferConverter.cs
+++ b/pkNX.WinForms/Dumping/FlatBufferConverter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Windows.Forms;

--- a/pkNX.WinForms/Properties/Resources.resx
+++ b/pkNX.WinForms/Properties/Resources.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -119,10 +119,10 @@
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="BattleTowerPoke8Archive" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\flatbuffers\battletowerpoke8archive.fbs;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>..\Resources\Flatbuffers\BattleTowerPoke8Archive.fbs;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="BattleTowerTrainer8Archive" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\flatbuffers\battletowertrainer8archive.fbs;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>..\Resources\Flatbuffers\BattleTowerTrainer8Archive.fbs;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="EncounterArchive7b" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\Flatbuffers\EncounterArchive7b.fbs;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -140,7 +140,7 @@
     <value>..\Resources\Flatbuffers\EncounterStatic8Archive.fbs;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="EncounterTrade8Archive" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\flatbuffers\encountertrade8archive.fbs;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>..\Resources\Flatbuffers\EncounterTrade8Archive.fbs;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="EncounterUnderground8Archive" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\Flatbuffers\EncounterUnderground8Archive.fbs;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -149,22 +149,22 @@
     <value>..\Resources\Flatbuffers\flatc.exe;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="NestHoleCrystalEncounter8Archive" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\flatbuffers\nestholecrystalencounter8archive.fbs;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>..\Resources\Flatbuffers\NestHoleCrystalEncounter8Archive.fbs;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="NestHoleDistributionEncounter8Archive" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\flatbuffers\nestholedistributionencounter8archive.fbs;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>..\Resources\Flatbuffers\NestHoleDistributionEncounter8Archive.fbs;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="NestHoleDistributionReward8Archive" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\flatbuffers\nestholedistributionreward8archive.fbs;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>..\Resources\Flatbuffers\NestHoleDistributionReward8Archive.fbs;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="NestHoleLevel8Archive" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\flatbuffers\nestholelevel8archive.fbs;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>..\Resources\Flatbuffers\NestHoleLevel8Archive.fbs;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="NestHoleReward8Archive" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\flatbuffers\nestholereward8archive.fbs;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>..\Resources\Flatbuffers\NestHoleReward8Archive.fbs;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="PlacementArea8Archive" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\flatbuffers\placementarea8archive.fbs;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>..\Resources\Flatbuffers\PlacementArea8Archive.fbs;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="Waza8" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\Flatbuffers\Waza8.fbs;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>

--- a/pkNX.WinForms/pkNX.WinForms.csproj
+++ b/pkNX.WinForms/pkNX.WinForms.csproj
@@ -13,6 +13,7 @@
     <AssemblyName>pkNX</AssemblyName>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
+    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
 
   <ItemGroup>

--- a/pkNX.WinForms/pkNX.WinForms.csproj
+++ b/pkNX.WinForms/pkNX.WinForms.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net46</TargetFrameworks>
+    <TargetFrameworks>net461</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <RootNamespace>pkNX.WinForms</RootNamespace>
     <Company>Project Pokémon</Company>

--- a/pkNX.WinForms/pkNX.WinForms.csproj
+++ b/pkNX.WinForms/pkNX.WinForms.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFrameworks>net461</TargetFrameworks>
@@ -85,5 +85,9 @@
     <None Include="Resources\Flatbuffers\NestHoleLevel8Archive.fbs" />
     <None Include="Resources\Flatbuffers\EncounterTrade8Archive.fbs" />
     <None Include="Resources\Flatbuffers\Waza8.fbs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Resources.Extensions" Version="5.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR fixes some things so that this program can be compiled on Linux using `msbuild` from Mono, or `dotnet build` from the .NET SDK, and then ran using Mono.

![image](https://user-images.githubusercontent.com/13039555/109410692-b0860700-796a-11eb-8871-dc3ac879e04f.png)

The fixes are:
- Removing `é` because of it causing a compile error.
- Making resource paths case sensitive.
- Adding references to `System.Resources.Extensions` because of this error:
```
/usr/share/dotnet/sdk/6.0.100-preview.1.21103.13/Microsoft.Common.CurrentVersion.targets(3136,5): error MSB3822: Non-string resources require the System.Resources.Extensions assembly at runtime, but it was not found in this project's references. [pkNX/pkNX.Sprites/pkNX.Sprites.csproj]
```
In order to do this, it seems to have been necessary to bump the .NET target version to 4.6.1.
- Adding `GenerateResourceUsePreserializedResources` because of this error:
```
/usr/share/dotnet/sdk/6.0.100-preview.1.21103.13/Microsoft.Common.CurrentVersion.targets(3136,5): error MSB3823: Non-string resources require the property GenerateResourceUsePreserializedResources to be set to true. [pkNX/pkNX.Sprites/pkNX.Sprites.csproj]
```
- Preferring the system `flatc` so that the native Linux binary will be used if installed.

Known issues/concerns:
- My knowledge of C# build systems is rather limited, so I'm not sure how correct some of these changes are.
- The _Wild Editor_ is very broken. Sprites do not load, and switching between different options at the top causes a `StackOverflowException`.
- This PR has unnecessary diffs at the top of some files that I haven't been able to get rid of.