### PR TITLE
Fix Personal Data editing for PLA

### DIFF
--- a/pkNX.Game/GameManagerPLA.cs
+++ b/pkNX.Game/GameManagerPLA.cs
@@ -81,8 +81,6 @@ namespace pkNX.Game
         protected override void Terminate()
         {
             // Store Personal Data back in the file. Let the container detect if it is modified.
-            var personal = this[GameFile.PersonalStats];
-            personal[0] = FlatBufferConverter.SerializeFrom(new PersonalTableLA { Table = Data.PersonalData.Table.Cast<PersonalInfoLA>().Select(z => z.FB).ToArray() } );
             var learn = this[GameFile.Learnsets];
             learn[0] = FlatBufferConverter.SerializeFrom(new Learnset8a { Table = Data.LevelUpData.LoadAll() });
             var evos = this[GameFile.Evolutions];


### PR DESCRIPTION
Personal Data is already written to the container here if it was modified in the editor. `Data.PersonalData` also is not set with modified data, so the modified data was being overwritten with the original.
https://github.com/kwsch/pkNX/blob/85ceb063ae491c761e11379b86ce096d69e524b2/pkNX.WinForms/MainEditor/EditorPLA.cs#L103-L112