### PR TITLE
Check for missing ExeFS or `main` executable in SWSH shiny editor

### DIFF
--- a/pkNX.WinForms/MainEditor/EditorSWSH.cs
+++ b/pkNX.WinForms/MainEditor/EditorSWSH.cs
@@ -110,7 +110,7 @@ namespace pkNX.WinForms.Controls
                 cache.Save();
         }
 
-        public void NotWorking_EditShinyRate()
+        public void EditShinyRate()
         {
             var path = Path.Combine(ROM.PathExeFS, "main");
             var data = FileMitm.ReadAllBytes(path);

--- a/pkNX.WinForms/MainEditor/EditorSWSH.cs
+++ b/pkNX.WinForms/MainEditor/EditorSWSH.cs
@@ -112,7 +112,17 @@ namespace pkNX.WinForms.Controls
 
         public void EditShinyRate()
         {
+            if (ROM.PathExeFS == null) {
+                WinFormsUtil.Alert("ExeFS not detected.");
+                return;
+            }
+
             var path = Path.Combine(ROM.PathExeFS, "main");
+            if (!File.Exists(path)) {
+                WinFormsUtil.Alert("Not able to find `main` file in ExeFS.");
+                return;
+            }
+
             var data = FileMitm.ReadAllBytes(path);
             var nso = new NSO(data);
 


### PR DESCRIPTION
A user sent me a chat on Reddit asking for this.

Tested locally on Shield v1.3.2