### PR TITLE
Fix map viewer

### DIFF
--- a/pkNX.Structures.FlatBuffers/Arceus/Placement/PlacementLocation8a.cs
+++ b/pkNX.Structures.FlatBuffers/Arceus/Placement/PlacementLocation8a.cs
@@ -71,11 +71,11 @@ public class PlacementLocation8a
     {
         if (ShapeID == ShapeIdSphere)
         {
-            if (!Parameters.Scale.IsDefault)
+            if (!Parameters.Scale.IsOne)
                 throw new NotImplementedException("Scaled spheres not yet supported!");
 
             var radius = Math.Abs(SizeX);
-            var distance = Parameters.Coordinates.DistanceTo(x, y, z);
+            var distance = Parameters.Coordinates.DistanceTo(new(x, y, z));
             return distance <= radius;
         }
         if (ShapeID == ShapeIdBox)
@@ -116,11 +116,11 @@ public class PlacementLocation8a
 
         if (ShapeID == ShapeIdSphere)
         {
-            if (!Parameters.Scale.IsDefault)
+            if (!Parameters.Scale.IsOne)
                 throw new NotImplementedException("Scaled spheres not yet supported!");
 
             var radius = Math.Abs(SizeX);
-            var distance = Parameters.Coordinates.DistanceTo(x, y, z);
+            var distance = Parameters.Coordinates.DistanceTo(new(x, y, z));
             return distance <= radius + sphereRadius;
         }
         if (ShapeID == ShapeIdBox)

--- a/pkNX.Structures.FlatBuffers/Arceus/Placement/PlacementV3f8a.cs
+++ b/pkNX.Structures.FlatBuffers/Arceus/Placement/PlacementV3f8a.cs
@@ -14,13 +14,36 @@ namespace pkNX.Structures.FlatBuffers;
 [FlatBufferTable, TypeConverter(typeof(ExpandableObjectConverter))]
 public class PlacementV3f8a : IEquatable<PlacementV3f8a>
 {
-    [FlatBufferItem(0)] public float X { get; set; }
-    [FlatBufferItem(1)] public float Y { get; set; }
-    [FlatBufferItem(2)] public float Z { get; set; }
-    public bool IsDefault => X is 1.0f && Y is 1.0f && Z is 1.0f;
+    [FlatBufferItem(0)] public float X { get; set; } = 0;
+    [FlatBufferItem(1)] public float Y { get; set; } = 0;
+    [FlatBufferItem(2)] public float Z { get; set; } = 0;
 
-    public double DistanceTo(PlacementV3f8a other) => DistanceTo(other.X, other.Y, other.Z);
-    public double DistanceTo(float x, float y, float z) => Math.Sqrt(Math.Pow(X - x, 2) + Math.Pow(Y - y, 2) + Math.Pow(Z - z, 2));
+    public PlacementV3f8a()
+    {
+        X = 0;
+        Y = 0;
+        Z = 0;
+    }
+
+    public PlacementV3f8a(float x = 0, float y = 0, float z = 0)
+    {
+        X = x;
+        Y = y;
+        Z = z;
+    }
+
+    public bool IsOne => X is 1 && Y is 1 && Z is 1;
+    public bool IsZero => X is 0 && Y is 0 && Z is 0;
+
+    public float Magnitude => (float)Math.Sqrt(MagnitudeSqr);
+    public float MagnitudeSqr => Dot(this);
+    public PlacementV3f8a Normalized => this * (1 / Magnitude);
+
+    public float Dot(PlacementV3f8a other) => X * other.X + Y * other.Y + Z * other.Z;
+    public PlacementV3f8a Cross(PlacementV3f8a other) => new(Y * other.Z - Z * other.Y, Z * other.X - X * other.Z, X * other.Y - Y * other.X);
+    public float DistanceTo(PlacementV3f8a other) => (this - other).Magnitude;
+    public float DistanceToSqr(PlacementV3f8a other) => (this - other).MagnitudeSqr;
+    public PlacementV3f8a Lerp(PlacementV3f8a other, float t) => this + (other - this) * t;
 
     public PlacementV3f8a Clone() => new()
     {
@@ -57,6 +80,18 @@ public class PlacementV3f8a : IEquatable<PlacementV3f8a>
             return hashCode;
         }
     }
+
+    public static PlacementV3f8a operator -(PlacementV3f8a v) => new(-v.X, -v.Y, -v.Z);
+
+    public static PlacementV3f8a operator +(PlacementV3f8a l, PlacementV3f8a r) => new(l.X + r.X, l.Y + r.Y, l.Z + r.Z);
+    public static PlacementV3f8a operator -(PlacementV3f8a l, PlacementV3f8a r) => new(l.X - r.X, l.Y - r.Y, l.Z - r.Z);
+    public static PlacementV3f8a operator *(PlacementV3f8a l, PlacementV3f8a r) => new(l.X * r.X, l.Y * r.Y, l.Z * r.Z);
+    public static PlacementV3f8a operator /(PlacementV3f8a l, PlacementV3f8a r) => new(l.X / r.X, l.Y / r.Y, l.Z / r.Z);
+
+    public static PlacementV3f8a operator +(PlacementV3f8a l, float r) => new(l.X + r, l.Y + r, l.Z + r);
+    public static PlacementV3f8a operator -(PlacementV3f8a l, float r) => new(l.X - r, l.Y - r, l.Z - r);
+    public static PlacementV3f8a operator *(PlacementV3f8a l, float r) => new(l.X * r, l.Y * r, l.Z * r);
+    public static PlacementV3f8a operator /(PlacementV3f8a l, float r) => new(l.X / r, l.Y / r, l.Z / r);
 
     public static bool operator ==(PlacementV3f8a? left, PlacementV3f8a? right) => Equals(left, right);
     public static bool operator !=(PlacementV3f8a? left, PlacementV3f8a? right) => !Equals(left, right);

--- a/pkNX.Structures.FlatBuffers/Arceus/Resident/AreaInstance8a.cs
+++ b/pkNX.Structures.FlatBuffers/Arceus/Resident/AreaInstance8a.cs
@@ -15,6 +15,8 @@ public sealed class AreaInstance8a
     public IReadOnlyList<AreaInstance8a> SubAreas => Children;
     public string AreaName => Area.AreaName;
 
+    public string FriendlyAreaName => Area.FriendlyAreaName;
+
     // Encount
     public EncounterTable8a[] Encounters => Area.Encounters;
 

--- a/pkNX.Structures.FlatBuffers/Arceus/Resident/AreaSettingsTable8a.cs
+++ b/pkNX.Structures.FlatBuffers/Arceus/Resident/AreaSettingsTable8a.cs
@@ -81,6 +81,25 @@ public class AreaSettings8a
     [FlatBufferItem(53)] public PlacementV3f8a Field_53 { get; set; } = new();
     [FlatBufferItem(54)] public ulong VisibleFlagHash { get; set; } //A flag from system_works
     [FlatBufferItem(55)] public bool Field_55 { get; set; }
+
+    // Get the in game name of the area
+    public string FriendlyAreaName
+    {
+        get
+        {
+            return Name switch
+            {
+                "ha_area00" => "Jubilife Village",
+                "ha_area01" => "Obsidian Fieldlands",
+                "ha_area02" => "Crimson Mirelands",
+                "ha_area03" => "Cobalt Coastlands",
+                "ha_area04" => "Cornet Highlands",
+                "ha_area05" => "Alabaster Icelands",
+                "ha_area06" => "Ancient Retreat",
+                _ => string.Format("Unknown Area ({0})", Name),
+            };
+        }
+    }
 }
 
 [FlatBufferTable, TypeConverter(typeof(ExpandableObjectConverter))]

--- a/pkNX.Structures.FlatBuffers/Arceus/Resident/Editing/ResidentArea8a.cs
+++ b/pkNX.Structures.FlatBuffers/Arceus/Resident/Editing/ResidentArea8a.cs
@@ -16,6 +16,7 @@ public sealed class ResidentArea8a
     }
 
     public string AreaName => Settings.Name;
+    public string FriendlyAreaName => Settings.FriendlyAreaName;
 
     // Encount
     public EncounterTable8a[] Encounters { get; private set; } = Array.Empty<EncounterTable8a>();

--- a/pkNX.WinForms/MainEditor/EditorPLA.cs
+++ b/pkNX.WinForms/MainEditor/EditorPLA.cs
@@ -327,7 +327,7 @@ internal class EditorPLA : EditorBase
         PopFlat<PokeMiscTable8a, PokeMisc8a>(GameFile.PokeMisc, "Misc Species Info Editor", z => $"{names[z.Species]}{(z.Form == 0 ? "" : $"-{z.Form}")} ~ {z.Value}");
     }
 
-    public void EditSpawns()
+    public void EditMap_viewer()
     {
         var resident = (GFPack)ROM.GetFile(GameFile.Resident);
         using var form = new MapViewer8a((GameManagerPLA)ROM, resident);

--- a/pkNX.WinForms/Subforms/MapViewer8a.Designer.cs
+++ b/pkNX.WinForms/Subforms/MapViewer8a.Designer.cs
@@ -32,18 +32,17 @@
             this.CB_Map = new System.Windows.Forms.ComboBox();
             this.CB_Species = new System.Windows.Forms.ComboBox();
             this.L_CoordinateMouse = new System.Windows.Forms.Label();
-            this.NUD_Tolerance = new System.Windows.Forms.NumericUpDown();
             this.L_SpawnDump = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_Tolerance)).BeginInit();
             this.SuspendLayout();
             // 
             // pictureBox1
             // 
             this.pictureBox1.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.pictureBox1.Location = new System.Drawing.Point(12, 12);
+            this.pictureBox1.Location = new System.Drawing.Point(20, 23);
+            this.pictureBox1.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
             this.pictureBox1.Name = "pictureBox1";
-            this.pictureBox1.Size = new System.Drawing.Size(512, 512);
+            this.pictureBox1.Size = new System.Drawing.Size(853, 985);
             this.pictureBox1.TabIndex = 0;
             this.pictureBox1.TabStop = false;
             this.pictureBox1.MouseMove += new System.Windows.Forms.MouseEventHandler(this.MapViewer8a_MouseMove);
@@ -52,9 +51,10 @@
             // 
             this.CB_Map.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CB_Map.FormattingEnabled = true;
-            this.CB_Map.Location = new System.Drawing.Point(530, 12);
+            this.CB_Map.Location = new System.Drawing.Point(883, 23);
+            this.CB_Map.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
             this.CB_Map.Name = "CB_Map";
-            this.CB_Map.Size = new System.Drawing.Size(121, 21);
+            this.CB_Map.Size = new System.Drawing.Size(199, 33);
             this.CB_Map.TabIndex = 1;
             this.CB_Map.SelectedIndexChanged += new System.EventHandler(this.CB_Map_SelectedIndexChanged);
             // 
@@ -63,57 +63,47 @@
             this.CB_Species.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
             this.CB_Species.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Species.FormattingEnabled = true;
-            this.CB_Species.Location = new System.Drawing.Point(530, 138);
+            this.CB_Species.Location = new System.Drawing.Point(883, 265);
+            this.CB_Species.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
             this.CB_Species.Name = "CB_Species";
-            this.CB_Species.Size = new System.Drawing.Size(121, 21);
+            this.CB_Species.Size = new System.Drawing.Size(199, 33);
             this.CB_Species.TabIndex = 2;
             this.CB_Species.SelectedIndexChanged += new System.EventHandler(this.CB_Species_SelectedIndexChanged);
             // 
             // L_CoordinateMouse
             // 
             this.L_CoordinateMouse.AutoSize = true;
-            this.L_CoordinateMouse.Location = new System.Drawing.Point(527, 510);
+            this.L_CoordinateMouse.Location = new System.Drawing.Point(878, 981);
+            this.L_CoordinateMouse.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
             this.L_CoordinateMouse.Name = "L_CoordinateMouse";
-            this.L_CoordinateMouse.Size = new System.Drawing.Size(153, 13);
+            this.L_CoordinateMouse.Size = new System.Drawing.Size(265, 25);
             this.L_CoordinateMouse.TabIndex = 3;
             this.L_CoordinateMouse.Text = "Hover over img for Coordinates";
             // 
-            // NUD_Tolerance
-            // 
-            this.NUD_Tolerance.Location = new System.Drawing.Point(530, 487);
-            this.NUD_Tolerance.Name = "NUD_Tolerance";
-            this.NUD_Tolerance.Size = new System.Drawing.Size(57, 20);
-            this.NUD_Tolerance.TabIndex = 4;
-            this.NUD_Tolerance.Value = new decimal(new int[] {
-            5,
-            0,
-            0,
-            0});
-            // 
             // L_SpawnDump
             // 
-            this.L_SpawnDump.Location = new System.Drawing.Point(530, 162);
+            this.L_SpawnDump.Location = new System.Drawing.Point(883, 312);
+            this.L_SpawnDump.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
             this.L_SpawnDump.Name = "L_SpawnDump";
-            this.L_SpawnDump.Size = new System.Drawing.Size(176, 322);
+            this.L_SpawnDump.Size = new System.Drawing.Size(293, 669);
             this.L_SpawnDump.TabIndex = 5;
             this.L_SpawnDump.Text = "~";
             this.L_SpawnDump.TextAlign = System.Drawing.ContentAlignment.BottomLeft;
             // 
             // MapViewer8a
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 25F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(709, 532);
+            this.ClientSize = new System.Drawing.Size(1182, 1023);
             this.Controls.Add(this.L_SpawnDump);
-            this.Controls.Add(this.NUD_Tolerance);
             this.Controls.Add(this.L_CoordinateMouse);
             this.Controls.Add(this.CB_Species);
             this.Controls.Add(this.CB_Map);
             this.Controls.Add(this.pictureBox1);
+            this.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
             this.Name = "MapViewer8a";
             this.Text = "MapViewer8a";
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_Tolerance)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -125,7 +115,6 @@
         private System.Windows.Forms.ComboBox CB_Map;
         private System.Windows.Forms.ComboBox CB_Species;
         private System.Windows.Forms.Label L_CoordinateMouse;
-        private System.Windows.Forms.NumericUpDown NUD_Tolerance;
         private System.Windows.Forms.Label L_SpawnDump;
     }
 }


### PR DESCRIPTION
- Updated `PlacementV3f8a` to include common vector math operations
- Added property `FriendlyAreaName` to convert the internal area name to the area's actual name, to be used for UI.

- Fix the map to display the correct map image to the area
- If the map image can't be found an error message will be displayed to the user
- Spawner circles are now drawn at the correct location
- The mouse position is now correctly converted to a location on the map
- The spawner displayed is now the spawner circle under the users mouse cursor
- Removed the mouse radius modifier

New editor preview:
<img width="623" alt="mapA" src="https://user-images.githubusercontent.com/60387522/189492116-2209e095-4c16-4318-a2f9-0ee589404330.png">

