### PR TITLE
Fix number formatting for certain culture info's

### DIFF
--- a/pkNX.WinForms/Main.cs
+++ b/pkNX.WinForms/Main.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
+using System.Threading;
 using System.Windows.Forms;
 using pkNX.Sprites;
 using pkNX.Structures;
@@ -22,6 +24,10 @@ namespace pkNX.WinForms
         public Main()
         {
             InitializeComponent();
+
+            // Fix number values displaying incorrectly for certain cultures.
+            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
 
             CB_Lang.SelectedIndex = Settings.Default.Language;
             if (!string.IsNullOrWhiteSpace(Settings.Default.GamePath))


### PR DESCRIPTION
My pc uses a culture info that displays numbers as "0,0" instead of "0.0". This can result in very confusing results.

I suggest to put the default culture to `InvariantCulture`.