### PR TITLE
Fix evo editor

### DIFF
--- a/pkNX.Structures.FlatBuffers/Arceus/EvolutionTable8.cs
+++ b/pkNX.Structures.FlatBuffers/Arceus/EvolutionTable8.cs
@@ -23,7 +23,7 @@ public class EvolutionTable8 : IFlatBufferArchive<EvolutionSet8a>
 [FlatBufferTable, TypeConverter(typeof(ExpandableObjectConverter))]
 public class EvolutionSet8a
 {
-    [FlatBufferItem(0)] public ushort Index { get; set; }
+    [FlatBufferItem(0)] public ushort Species { get; set; }
     [FlatBufferItem(1)] public ushort Form { get; set; }
     [FlatBufferItem(2)] public EvolutionEntry8a[]? Table { get; set; } = Array.Empty<EvolutionEntry8a>();
 

--- a/pkNX.WinForms/Dumping/GameDumperPLA.cs
+++ b/pkNX.WinForms/Dumping/GameDumperPLA.cs
@@ -325,7 +325,7 @@ namespace pkNX.WinForms
                 var e = obj.Table[i];
                 if (e.Table?.Length is not > 0)
                     continue;
-                var index = pt.GetFormIndex(e.Index, (byte)e.Form);
+                var index = pt.GetFormIndex(e.Species, (byte)e.Form);
                 var entry = (IPersonalInfoPLA)pt[index];
                 if (!entry.IsPresentInGame)
                     continue;

--- a/pkNX.WinForms/Dumping/PersonalDumperPLA.cs
+++ b/pkNX.WinForms/Dumping/PersonalDumperPLA.cs
@@ -188,7 +188,7 @@ namespace pkNX.WinForms
 
         private void AddEvolutions(List<string> lines, int species, int form)
         {
-            var evo = Array.Find(Evos, z => z.Index == species && z.Form == form);
+            var evo = Array.Find(Evos, z => z.Species == species && z.Form == form);
             if (evo?.Table is null)
                 return;
             var evo2 = evo.Table.Where(z => z.Species != 0).ToArray();

--- a/pkNX.WinForms/MainEditor/EditorPLA.cs
+++ b/pkNX.WinForms/MainEditor/EditorPLA.cs
@@ -426,7 +426,7 @@ internal class EditorPLA : EditorBase
     {
         var names = ROM.GetStrings(TextName.SpeciesNames);
         PopFlat<EvolutionTable8, EvolutionSet8a>(GameFile.Evolutions, "Evolution Editor",
-            z => $"{names[z.Index]}{(z.Form != 0 ? $"-{z.Form}" : "")}");
+            z => $"{names[z.Species]}{(z.Form != 0 ? $"-{z.Form}" : "")}");
     }
 
     public void EditOutbreakDetail()

--- a/pkNX.WinForms/Subforms/PokeDataUI8a.cs
+++ b/pkNX.WinForms/Subforms/PokeDataUI8a.cs
@@ -194,7 +194,8 @@ namespace pkNX.WinForms
             var form = formVal[index];
             LoadPersonal((IPersonalInfoPLA)Data.PersonalData[index]);
             LoadLearnset(Editor.Learn[index]);
-            LoadEvolutions(Editor.Evolve[index]);
+            var evoTable = Editor.Evolve.Root.Table;
+            LoadEvolutions(evoTable.FirstOrDefault(x => x.Species == spec && x.Form == form));
 
             Bitmap rawImg = (Bitmap)SpriteUtil.GetSprite(spec, form, 0, 0, false, false, false);
             Bitmap bigImg = ResizeBitmap(rawImg, rawImg.Width * 2, rawImg.Height * 2);

--- a/pkNX.WinForms/Subforms/PokeDataUI8a.cs
+++ b/pkNX.WinForms/Subforms/PokeDataUI8a.cs
@@ -197,19 +197,19 @@ namespace pkNX.WinForms
             LoadEvolutions(Editor.Evolve[index]);
 
             Bitmap rawImg = (Bitmap)SpriteUtil.GetSprite(spec, form, 0, 0, false, false, false);
-            Bitmap bigImg = new(rawImg.Width * 2, rawImg.Height * 2);
-            for (int x = 0; x < rawImg.Width; x++)
-            {
-                for (int y = 0; y < rawImg.Height; y++)
-                {
-                    Color c = rawImg.GetPixel(x, y);
-                    bigImg.SetPixel(2 * x, 2 * y, c);
-                    bigImg.SetPixel((2 * x) + 1, 2 * y, c);
-                    bigImg.SetPixel(2 * x, (2 * y) + 1, c);
-                    bigImg.SetPixel((2 * x) + 1, (2 * y) + 1, c);
-                }
-            }
+            Bitmap bigImg = ResizeBitmap(rawImg, rawImg.Width * 2, rawImg.Height * 2);
             PB_MonSprite.Image = bigImg;
+        }
+
+        private Bitmap ResizeBitmap(Bitmap sourceBMP, int width, int height)
+        {
+            Bitmap result = new(width, height);
+            using (Graphics g = Graphics.FromImage(result))
+            {
+                g.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.NearestNeighbor;
+                g.DrawImage(sourceBMP, 0, 0, width, height);
+            }
+            return result;
         }
 
         private void SaveCurrent()


### PR DESCRIPTION
Rename `Index` to `Species`. It's not actually the index of the table.

To get it functional I'm just doing a full on `where` search on the evo table. 
`evoTable.FirstOrDefault(x => x.Species == spec && x.Form == form)`
We'd have to code the same table reorganize as is done on the personal info table, to get it done properly.

Updated the resize code to use graphics instead