### PR TITLE
Assign unique item names in editor

### DIFF
--- a/pkNX.WinForms/MainEditor/EditorPLA.cs
+++ b/pkNX.WinForms/MainEditor/EditorPLA.cs
@@ -564,7 +564,10 @@ internal class EditorPLA : EditorBase
         var data = obj[0];
         var items = Item8a.GetArray(data);
         var cache = new DataCache<Item8a>(items);
-        using var form = new GenericEditor<Item8a>(cache, ROM.GetStrings(TextName.ItemNames), "Item Editor");
+
+        var itemNames = ROM.GetStrings(TextName.ItemNames).Select((x, i) => $"{x} ({i})").ToArray();
+
+        using var form = new GenericEditor<Item8a>(cache, itemNames, "Item Editor");
         form.ShowDialog();
         if (!form.Modified)
         {


### PR DESCRIPTION
Fix item name duplicates causing the editor to switch between entries