### PR TITLE
Fix hit count order

### DIFF
--- a/pkNX.Structures.FlatBuffers/Arceus/Waza8a.cs
+++ b/pkNX.Structures.FlatBuffers/Arceus/Waza8a.cs
@@ -27,8 +27,8 @@ public class Waza8a : IMove
     [FlatBufferItem(06), Browsable(false)] public byte FAccuracy  { get; set; } // byte
     [FlatBufferItem(07), Browsable(false)] public byte FPP        { get; set; } // byte
     [FlatBufferItem(08), Browsable(false)] public sbyte FPriority { get; set; } // byte
-    [FlatBufferItem(09), Browsable(false)] public byte FHitMin    { get; set; } // byte
-    [FlatBufferItem(10), Browsable(false)] public byte FHitMax    { get; set; } // byte
+    [FlatBufferItem(09), Browsable(false)] public byte FHitMax    { get; set; } // byte
+    [FlatBufferItem(10), Browsable(false)] public byte FHitMin    { get; set; } // byte
     [FlatBufferItem(11), Browsable(false)] public short FInflict  { get; set; } // ushort
     [FlatBufferItem(12), Browsable(false)] public byte FInflictPercent  { get; set; } // byte
     [FlatBufferItem(13), Browsable(false)] public byte FRawInflictCount { get; set; } // byte

--- a/pkNX.Structures.FlatBuffers/Gen8/Other/Waza8.cs
+++ b/pkNX.Structures.FlatBuffers/Gen8/Other/Waza8.cs
@@ -27,8 +27,8 @@ public class Waza8 : IMove
     [FlatBufferItem(07), Browsable(false)] public byte   FAccuracy { get; set; }
     [FlatBufferItem(08), Browsable(false)] public byte   FPP { get; set; }
     [FlatBufferItem(09), Browsable(false)] public byte   FPriority { get; set; }
-    [FlatBufferItem(10), Browsable(false)] public byte   FHitMin { get; set; }
-    [FlatBufferItem(11), Browsable(false)] public byte   FHitMax { get; set; }
+    [FlatBufferItem(10), Browsable(false)] public byte   FHitMax { get; set; }
+    [FlatBufferItem(11), Browsable(false)] public byte   FHitMin { get; set; }
     [FlatBufferItem(12), Browsable(false)] public ushort FInflict { get; set; }
     [FlatBufferItem(13), Browsable(false)] public byte   FInflictPercent { get; set; }
     [FlatBufferItem(14), Browsable(false)] public byte   FRawInflictCount { get; set; }


### PR DESCRIPTION
This swaps the HitMin and HitMax fields for the Legends Arceus and Sword/Shield move data flatbuffers, since the previous ordering was incorrect. This is already correct in the Scarlet/Violet move data flatbuffer.