### PR TITLE
Label PersonalTable9 Field16

### DIFF
--- a/pkNX.Structures.FlatBuffers/Gen9/Personal/PersonalTable9SVfb.cs
+++ b/pkNX.Structures.FlatBuffers/Gen9/Personal/PersonalTable9SVfb.cs
@@ -42,9 +42,9 @@ public class PersonalInfo9SVfb
     [FlatBufferItem(13)] public PersonalInfo9SVHatch Hatch { get; set; } = new();
     [FlatBufferItem(14)] public byte HatchCycles { get; set; } // byte
     [FlatBufferItem(15)] public byte BaseFriendship { get; set; } // byte
-    [FlatBufferItem(16)] public short U16 { get; set; } // byte // Chansey Blissey Happiny Slaking
+    [FlatBufferItem(16)] public short BaseEXPAddend { get; set; } // short
     [FlatBufferItem(17)] public byte EvoStage { get; set; } // byte
-    [FlatBufferItem(18)] public bool U18 { get; set; } // Silvally, Sylveon, Arceus have this flag.
+    [FlatBufferItem(18)] public bool U18 { get; set; } // Silvally, Sylveon (1.0.0), Arceus have this flag.
     [FlatBufferItem(19)] public PersonalInfo9SVStats EVYield { get; set; } = new();
     [FlatBufferItem(20)] public PersonalInfo9SVStats Base { get; set; } = new();
     [FlatBufferItem(21)] public PersonalInfo9SVEvolutions[] Evolutions { get; set; } = Array.Empty<PersonalInfo9SVEvolutions>();


### PR DESCRIPTION
Field16 in PersonalTable9 is the base EXP addend, which is added to the base EXP calculated using the base stat total and the evo stage.
```
Y | Chansey: 237
Y | Blissey: 365
N | Poochyena: 12
N | Zigzagoon: 8
N | Zigzagoon-1: 8
N | Wurmple: 17
Y | Slaking: -50
Y | Happiny: 66
N | Audino: 234
N | Audino-1: 234
N | Archen: -9
N | Archeops: -21
N | Floette-5: 50
N | Wooloo: 68
```

I also looked into Field18, though I cannot figure out its usage. It appears to be set for Pokemon that have moves that can change types. For example, it was set for Sylveon in 1.0.0 only, either as a mistake or due to its hidden ability, Pixilate. It is also set for every Arceus and Silvally form, and they both have signature moves that change typing based on held item (Judgment, Multi-Attack).

Also, quick question - what is with Field2 being set as a FlatBufferStruct? From what I understand of the flatbuffer binary format, if a field is a struct, it will always have a non-zero field offset value within the vtable, which is not the case for Field2.