### PR TITLE
[Fix #357] Update AreaEditor8a.cs to save AreaSettings

### DIFF
--- a/pkNX.WinForms/Subforms/AreaEditor8a.cs
+++ b/pkNX.WinForms/Subforms/AreaEditor8a.cs
@@ -163,9 +163,38 @@ public partial class AreaEditor8a : Form
 
     private void AreaEditor8a_FormClosing(object sender, FormClosingEventArgs e)
     {
-        if (Save)
+        if (Save){
             SaveArea();
-        else
+            SaveSettings();
+        }
+        else {
             Resident.CancelEdits();
+        }
+    }
+
+    private void SaveSettings()
+    {
+        TryWrite("bin/field/resident/AreaSettings.bin", Settings);
+    }
+
+    private static byte[] Write<T>(T obj) where T : class, IFlatBufferSerializable<T>
+    {
+        var pool = ArrayPool<byte>.Shared;
+        var serializer = obj.Serializer;
+        var data = pool.Rent(serializer.GetMaxSize(obj));
+        var len = serializer.Write(data, obj);
+        var result = data.AsSpan(0, len).ToArray();
+        pool.Return(data);
+        return result;
+    }
+
+    private void TryWrite<T>(string path, T obj) where T : class, IFlatBufferSerializable<T>
+    {
+        var index = Resident.GetIndexFull(path);
+        if (index == -1)
+            return;
+
+        byte[] result = Write(obj);
+        Resident[index] = result;
     }
 }


### PR DESCRIPTION
So, I think this did it. Well, I'm sure it works, the Field/Areas Settings tab will save as intended,  I'm just not sure it creates other problems. So I did it in the most analogous way, without any optimization, so that it's very explicit what it's doing. But feel free to edit it.

By the way, I managed to find out that Flag03 is essentially "Can Ride", i.e., if you enable it in Jubilife Village, you'll be able to ride Pokémon there.

Best regards.