### PR TITLE
Preserve TextFile flags

### DIFF
--- a/pkNX.Structures/Text/TextLineInfo.cs
+++ b/pkNX.Structures/Text/TextLineInfo.cs
@@ -3,5 +3,6 @@ namespace pkNX.Structures;
 internal class TextLine
 {
     public int Offset;
-    public int Length;
+    public ushort Length;
+    public ushort Flags;
 }

--- a/pkNX.WinForms/Subforms/TextContainer.cs
+++ b/pkNX.WinForms/Subforms/TextContainer.cs
@@ -43,7 +43,8 @@ public class TextContainer
         {
             if (Cache[i] is not { } x)
                 continue;
-            Container[i] = TextFile.GetBytes(x, Config, Remap);
+            var flags = new ushort[x.Length]; // TODO: handle properly, for now just zero-out flags
+            Container[i] = TextFile.GetBytes(x, flags, Config, Remap);
         }
     }
 }

--- a/pkNX.WinForms/UI/WPFTextEditor.xaml
+++ b/pkNX.WinForms/UI/WPFTextEditor.xaml
@@ -62,6 +62,7 @@
                 <DataGridTextColumn Header="Line" IsReadOnly="True" Binding="{Binding Line}"/>
                 <DataGridTextColumn Header="Variable" Binding="{Binding Variable}"/>
                 <DataGridTextColumn Header="Hash" IsReadOnly="True" Binding="{Binding Hash, StringFormat=0x\{0:X16\}}" Visibility="{Binding Source={x:Reference CHK_ShowHashes}, Path=IsChecked, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                <DataGridTextColumn Header="Flags" Binding="{Binding Flags}"/>
                 <DataGridTextColumn Header="Text" Binding="{Binding Text}"/>
             </DataGrid.Columns>
         </DataGrid>


### PR DESCRIPTION
The last two bytes of each `TextLineInfo` entry contains a number of bit fields that were previously being ignored/discarded. These appear to be used primarily for grammar-related purposes, such as:

- `0x0004` in English means that the indefinite article should be "an", like in "an Ultra Ball", "an Antidote", etc., rather than "a Poké Ball", "a Revive", etc.
- `0x0001` in Spanish means it's feminine, so it should be written "la Poké Ball", "una Limonada", etc. rather than "el Antídoto", "un Éter", etc.

I've made it so these are displayed and exportable in the WPFTextEditor, but I haven't backported the changes to the old TextEditor.